### PR TITLE
LocalTime uses a new nanos-of-the-day logical

### DIFF
--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/temporal.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/decoders/temporal.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.decoders
 
-import com.sksamuel.avro4s.schemas.TimestampNanosLogicalType
+import com.sksamuel.avro4s.schemas.{NanosOfTheDayLogicalType, TimestampNanosLogicalType}
 import com.sksamuel.avro4s.{Avro4sConfigurationException, Decoder, SchemaFor}
 import org.apache.avro.LogicalTypes.{TimeMicros, TimeMillis, TimestampMicros, TimestampMillis}
 import org.apache.avro.Schema
@@ -42,6 +42,7 @@ trait TemporalDecoders:
       val toNanosFactor = schema.getLogicalType match {
         case _: TimeMicros => 1000L
         case _: TimeMillis => 1000000L
+        case NanosOfTheDayLogicalType => 1L
         case _ => throw new Avro4sConfigurationException(s"Unsupported logical type for LocalTime: ${schema}")
       }
 

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/temporal.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/encoders/temporal.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.avro4s.encoders
 
-import com.sksamuel.avro4s.schemas.TimestampNanosLogicalType
+import com.sksamuel.avro4s.schemas.{NanosOfTheDayLogicalType, TimestampNanosLogicalType}
 import com.sksamuel.avro4s.{Avro4sConfigurationException, Encoder, SchemaFor}
 import org.apache.avro.LogicalTypes.{TimeMicros, TimeMillis, TimestampMicros, TimestampMillis}
 import org.apache.avro.Schema
@@ -31,6 +31,7 @@ object LocalTimeEncoder extends Encoder[LocalTime] :
     val toNanosFactor = schema.getLogicalType match {
       case _: TimeMicros => 1000L
       case _: TimeMillis => 1000000L
+      case NanosOfTheDayLogicalType => 1L
       case _ => throw new Avro4sConfigurationException(s"Unsupported logical type for LocalTime: ${schema}")
     }
     { value => java.lang.Long.valueOf(value.toNanoOfDay / toNanosFactor) }

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/logicals.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/logicals.scala
@@ -19,3 +19,12 @@ object TimestampNanosLogicalType extends LogicalType("timestamp-nanos") {
     }
   }
 }
+
+object NanosOfTheDayLogicalType extends LogicalType("nanos-of-the-day") {
+  override def validate(schema: Schema): Unit = {
+    super.validate(schema)
+    if (schema.getType != Schema.Type.LONG) {
+      throw new IllegalArgumentException("Logical type nanos-of-the-day must be backed by long")
+    }
+  }
+}

--- a/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/temporal.scala
+++ b/avro4s-core/src/main/scala/com/sksamuel/avro4s/schemas/temporal.scala
@@ -14,5 +14,5 @@ trait TemporalSchemas:
   given LocalDateSchemaFor: SchemaFor[LocalDate] = DateSchemaFor.forType
   given LocalDateTimeSchemaFor : SchemaFor[LocalDateTime] = SchemaFor(TimestampNanosLogicalType.addToSchema(SchemaBuilder.builder.longType))
   given OffsetDateTimeSchemaFor : SchemaFor[OffsetDateTime] = SchemaFor(OffsetDateTimeLogicalType.addToSchema(SchemaBuilder.builder.stringType))
-  given LocalTimeSchemaFor : SchemaFor[LocalTime] = SchemaFor(LogicalTypes.timeMicros().addToSchema(SchemaBuilder.builder.longType))
+  given LocalTimeSchemaFor : SchemaFor[LocalTime] = SchemaFor(NanosOfTheDayLogicalType.addToSchema(SchemaBuilder.builder.longType))
   given TimestampSchemaFor : SchemaFor[Timestamp] = SchemaFor[Timestamp](LogicalTypes.timestampMillis().addToSchema(SchemaBuilder.builder.longType))

--- a/avro4s-core/src/test/resources/localtime.json
+++ b/avro4s-core/src/test/resources/localtime.json
@@ -7,7 +7,7 @@
       "name": "time",
       "type": {
         "type": "long",
-        "logicalType": "time-micros"
+        "logicalType": "nanos-of-the-day"
       }
     }
   ]

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/github/GithubIssue387.scala
@@ -11,18 +11,13 @@ class GithubIssue387 extends AnyWordSpec with Matchers {
 
   "LocalTime" must {
 
-    "encode the value to a int represented as milliseconds since midnight" in {
+    "encode the value to a long represented as nanoseconds since midnight" in {
       val localTime = LocalTime.now()
       val encoded = Encoder[LocalTime].encode(AvroSchema[LocalTime]).apply(localTime)
-      encoded shouldBe localTime.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
+      encoded shouldBe localTime.toNanoOfDay
     }
 
-    "encode the value and truncate any precision beyond milliseconds" in {
-      val encoded = Encoder[LocalTime].encode(AvroSchema[LocalTime]).apply(LocalTime.MAX)
-      encoded shouldBe LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND
-    }
-
-    "encode and decode back to an equivalent LocalTime object when Local has microsecond precision" in {
+    "encode and decode back to an equivalent LocalTime object when Local has nanosecond precision" in {
       val localTime = LocalTime.now()
       val encoded = Encoder[LocalTime].encode(AvroSchema[LocalTime]).apply(localTime)
       val decoded = Decoder[LocalTime].decode(AvroSchema[LocalTime]).apply(encoded)
@@ -30,12 +25,12 @@ class GithubIssue387 extends AnyWordSpec with Matchers {
       decoded.toNanoOfDay shouldBe localTime.toNanoOfDay
     }
 
-    "encode and decode back to a LocalTime object with an equivalent time to  microsecond precision" in {
+    "encode and decode back to a LocalTime object with an equivalent time to nanosecond precision" in {
       val encoded = Encoder[LocalTime].encode(AvroSchema[LocalTime]).apply(LocalTime.MAX)
       val decoded = Decoder[LocalTime].decode(AvroSchema[LocalTime]).apply(encoded)
-      decoded should not be LocalTime.MAX
-      // compare to a LocalTime.MAX that has had the time precision truncated to milliseconds
-      decoded shouldBe LocalTime.ofNanoOfDay((LocalTime.MAX.toNanoOfDay / NANOSECONDS_IN_A_MICROSECOND) * NANOSECONDS_IN_A_MICROSECOND)
+      decoded shouldBe LocalTime.MAX
+      // compare to a LocalTime.MAX that has nanosecond precision
+      decoded shouldBe LocalTime.ofNanoOfDay(LocalTime.MAX.toNanoOfDay)
     }
 
   }

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/DateDecoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/decoder/DateDecoderTest.scala
@@ -18,10 +18,10 @@ class DateDecoderTest extends AnyFunSuite with Matchers {
   case class WithTimestamp(z: Timestamp)
   case class WithInstant(z: Instant)
 
-  test("decode int to LocalTime") {
+  test("decode long to LocalTime") {
     val schema = AvroSchema[WithLocalTime]
     val record = new GenericData.Record(schema)
-    record.put("z", 46245000000L)
+    record.put("z", 46245000000000L)
     Decoder[WithLocalTime].decode(schema).apply(record) shouldBe WithLocalTime(LocalTime.of(12, 50, 45))
   }
 

--- a/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/DateEncoderTest.scala
+++ b/avro4s-core/src/test/scala/com/sksamuel/avro4s/record/encoder/DateEncoderTest.scala
@@ -10,10 +10,10 @@ import org.scalatest.matchers.should.Matchers
 
 class DateEncoderTest extends AnyFunSuite with Matchers {
 
-  test("encode LocalTime as TIME-MILLIS") {
+  test("encode LocalTime as nanoseconds of the day") {
     case class Foo(s: LocalTime)
     val schema = AvroSchema[Foo]
-    Encoder[Foo].encode(schema).apply(Foo(LocalTime.of(12, 50, 45))) shouldBe expectedRecord(schema, 46245000000L)
+    Encoder[Foo].encode(schema).apply(Foo(LocalTime.of(12, 50, 45))) shouldBe expectedRecord(schema, 46245000000000L)
   }
 
   test("encode LocalDate as DATE") {


### PR DESCRIPTION
The issue was originally created [here](https://github.com/sksamuel/avro4s/issues/741).

The content is the same as [this closed PR](https://github.com/sksamuel/avro4s/pull/742).

We highly discourage using `LocalTime` in any data model. Using long type for Epoch time works much better. The user is forced to consider the precision (millisecond, second, etc.) when data modeling. 